### PR TITLE
feat: Match events

### DIFF
--- a/src/components/Score.test.tsx
+++ b/src/components/Score.test.tsx
@@ -5,17 +5,81 @@ import { Score } from './Score';
 import { Match } from '../types/Match';
 
 describe('Score component', () => {
-  const match: Match = {
-    homeTeam: 'Real Madrid',
-    awayTeam: 'Barcelona',
-    homeScore: 2,
-    awayScore: 1,
-    id: 'Real Madrid - Barcelona',
-    date: new Date(),
-  };
+  it('renders the correct score when match just started', () => {
+    const match: Match = {
+      homeTeam: 'Real Madrid',
+      awayTeam: 'Barcelona',
+      homeScore: 0,
+      awayScore: 0,
+      id: 'Real Madrid - Barcelona',
+      date: new Date(),
+      goals: [],
+    };
 
-  it('renders the correct score', () => {
     const { getByText } = render(<Score match={match} />);
-    expect(getByText('Real Madrid 2 - Barcelona 1')).toBeInTheDocument();
+    expect(getByText('Real Madrid - Barcelona: 0 - 0')).toBeInTheDocument();
+  });
+
+  it('renders the correct score when one goal scored', () => {
+    const date = new Date();
+    const match: Match = {
+      homeTeam: 'Real Madrid',
+      awayTeam: 'Barcelona',
+      homeScore: 1,
+      awayScore: 0,
+      id: 'Real Madrid - Barcelona',
+      date,
+      goals: [
+        {
+          date: new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes() + 5
+          ),
+        },
+      ],
+    };
+
+    const { getByText } = render(<Score match={match} />);
+    expect(getByText('Real Madrid - Barcelona: 1 - 0 5"')).toBeInTheDocument();
+  });
+
+  it('renders the correct score when two goals scored', () => {
+    const date = new Date();
+    const match: Match = {
+      homeTeam: 'Real Madrid',
+      awayTeam: 'Barcelona',
+      homeScore: 1,
+      awayScore: 1,
+      id: 'Real Madrid - Barcelona',
+      date,
+      goals: [
+        {
+          date: new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes() + 5
+          ),
+        },
+        {
+          date: new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes() + 20
+          ),
+        },
+      ],
+    };
+
+    const { getByText } = render(<Score match={match} />);
+    expect(
+      getByText('Real Madrid - Barcelona: 1 - 1 5" 20"')
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/Score.test.tsx
+++ b/src/components/Score.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Score } from './Score';
 import { Match } from '../types/Match';
+import { MatchEventType } from '../types/MatchEventType';
+import { CardType } from '../types/CardType';
 
 describe('Score component', () => {
   it('renders the correct score when match just started', () => {
@@ -13,7 +15,7 @@ describe('Score component', () => {
       awayScore: 0,
       id: 'Real Madrid - Barcelona',
       date: new Date(),
-      goals: [],
+      events: [],
     };
 
     const { getByText } = render(<Score match={match} />);
@@ -29,8 +31,9 @@ describe('Score component', () => {
       awayScore: 0,
       id: 'Real Madrid - Barcelona',
       date,
-      goals: [
+      events: [
         {
+          type: MatchEventType.Goal,
           date: new Date(
             date.getFullYear(),
             date.getMonth(),
@@ -48,7 +51,7 @@ describe('Score component', () => {
 
     const { getByText } = render(<Score match={match} />);
     expect(
-      getByText('Real Madrid - Barcelona: 1 - 0 5" (R.L)')
+      getByText('Real Madrid - Barcelona: 1 - 0 GL 5" (R.L)')
     ).toBeInTheDocument();
   });
 
@@ -61,8 +64,9 @@ describe('Score component', () => {
       awayScore: 1,
       id: 'Real Madrid - Barcelona',
       date,
-      goals: [
+      events: [
         {
+          type: MatchEventType.Goal,
           date: new Date(
             date.getFullYear(),
             date.getMonth(),
@@ -76,6 +80,7 @@ describe('Score component', () => {
           },
         },
         {
+          type: MatchEventType.Goal,
           date: new Date(
             date.getFullYear(),
             date.getMonth(),
@@ -93,7 +98,95 @@ describe('Score component', () => {
 
     const { getByText } = render(<Score match={match} />);
     expect(
-      getByText('Real Madrid - Barcelona: 1 - 1 5" (R.L) 20" (L.M)')
+      getByText('Real Madrid - Barcelona: 1 - 1 GL 5" (R.L) GL 20" (L.M)')
+    ).toBeInTheDocument();
+  });
+
+  test.each(Object.values(CardType))(
+    'renders the correct card when %s card issued',
+    (cardType) => {
+      const date = new Date();
+      const match: Match = {
+        homeTeam: 'Real Madrid',
+        awayTeam: 'Barcelona',
+        homeScore: 0,
+        awayScore: 0,
+        id: 'Real Madrid - Barcelona',
+        date,
+        events: [
+          {
+            type: MatchEventType.Card,
+            date: new Date(
+              date.getFullYear(),
+              date.getMonth(),
+              date.getDate(),
+              date.getHours(),
+              date.getMinutes() + 5
+            ),
+            player: {
+              firstName: 'Robert',
+              lastName: 'Lewandowski',
+            },
+            cardType,
+          },
+        ],
+      };
+
+      const { getByText } = render(<Score match={match} />);
+      const expectedEventType = cardType === CardType.Red ? 'RD' : 'YL';
+      expect(
+        getByText(
+          `Real Madrid - Barcelona: 0 - 0 ${expectedEventType} 5" (R.L)`
+        )
+      ).toBeInTheDocument();
+    }
+  );
+
+  it('handles mix of goals and scores', () => {
+    const date = new Date();
+    const match: Match = {
+      homeTeam: 'Real Madrid',
+      awayTeam: 'Barcelona',
+      homeScore: 1,
+      awayScore: 0,
+      id: 'Real Madrid - Barcelona',
+      date,
+      events: [
+        {
+          type: MatchEventType.Goal,
+          date: new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes() + 5
+          ),
+          player: {
+            firstName: 'Robert',
+            lastName: 'Lewandowski',
+          },
+        },
+        {
+          type: MatchEventType.Card,
+          date: new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes() + 20
+          ),
+          player: {
+            firstName: 'Luka',
+            lastName: 'Modrić',
+          },
+          cardType: CardType.Yellow,
+        },
+      ],
+    };
+
+    const { getByText } = render(<Score match={match} />);
+    expect(
+      getByText('Real Madrid - Barcelona: 1 - 0 GL 5" (R.L) YL 20" (L.M)')
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Score.test.tsx
+++ b/src/components/Score.test.tsx
@@ -38,12 +38,18 @@ describe('Score component', () => {
             date.getHours(),
             date.getMinutes() + 5
           ),
+          player: {
+            firstName: 'Robert',
+            lastName: 'Lewandowski',
+          },
         },
       ],
     };
 
     const { getByText } = render(<Score match={match} />);
-    expect(getByText('Real Madrid - Barcelona: 1 - 0 5"')).toBeInTheDocument();
+    expect(
+      getByText('Real Madrid - Barcelona: 1 - 0 5" (R.L)')
+    ).toBeInTheDocument();
   });
 
   it('renders the correct score when two goals scored', () => {
@@ -64,6 +70,10 @@ describe('Score component', () => {
             date.getHours(),
             date.getMinutes() + 5
           ),
+          player: {
+            firstName: 'Robert',
+            lastName: 'Lewandowski',
+          },
         },
         {
           date: new Date(
@@ -73,13 +83,17 @@ describe('Score component', () => {
             date.getHours(),
             date.getMinutes() + 20
           ),
+          player: {
+            firstName: 'Luka',
+            lastName: 'Modrić',
+          },
         },
       ],
     };
 
     const { getByText } = render(<Score match={match} />);
     expect(
-      getByText('Real Madrid - Barcelona: 1 - 1 5" 20"')
+      getByText('Real Madrid - Barcelona: 1 - 1 5" (R.L) 20" (L.M)')
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -17,7 +17,8 @@ export function Score({ match }: ScoreProps) {
       (goal) =>
         Math.ceil(
           (goal.date.getTime() - date.getTime()) / 1000 / 60
-        ).toString() + '"'
+        ).toString() +
+        `" (${goal.player.firstName[0]}.${goal.player.lastName[0]})`
     )
     .join(' ')
     .trim();

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -11,6 +11,18 @@ export interface ScoreProps {
  * @returns {JSX.Element} - The rendered score as a list item.
  */
 export function Score({ match }: ScoreProps) {
-  const { homeTeam, awayTeam, homeScore, awayScore } = match;
-  return <li>{`${homeTeam} ${homeScore} - ${awayTeam} ${awayScore}`}</li>;
+  const { homeTeam, awayTeam, homeScore, awayScore, goals, date } = match;
+  const scores = goals
+    .map(
+      (goal) =>
+        Math.ceil(
+          (goal.date.getTime() - date.getTime()) / 1000 / 60
+        ).toString() + '"'
+    )
+    .join(' ')
+    .trim();
+
+  return (
+    <li>{`${homeTeam} - ${awayTeam}: ${homeScore} - ${awayScore} ${scores}`}</li>
+  );
 }

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Match } from '../types/Match';
+import { MatchEventType } from '../types/MatchEventType';
+import { CardType } from '../types/CardType';
+import { MatchEvent } from '../types/MatchEvent';
 
 export interface ScoreProps {
   match: Match;
@@ -11,17 +14,28 @@ export interface ScoreProps {
  * @returns {JSX.Element} - The rendered score as a list item.
  */
 export function Score({ match }: ScoreProps) {
-  const { homeTeam, awayTeam, homeScore, awayScore, goals, date } = match;
-  const scores = goals
-    .map(
-      (goal) =>
-        Math.ceil(
-          (goal.date.getTime() - date.getTime()) / 1000 / 60
-        ).toString() +
-        `" (${goal.player.firstName[0]}.${goal.player.lastName[0]})`
-    )
-    .join(' ')
-    .trim();
+  const { homeTeam, awayTeam, homeScore, awayScore, events, date } = match;
+  const scores = events
+    .map((event) => {
+      const eventTime = Math.ceil(
+        (event.date.getTime() - date.getTime()) / 1000 / 60
+      );
+
+      const playerInitials = `${event.player.firstName[0]}.${event.player.lastName[0]}`;
+
+      const eventTypeFormatter = (event: MatchEvent) => {
+        if (event.type === MatchEventType.Card) {
+          return event.cardType === CardType.Yellow ? 'YL' : 'RD';
+        } else if ((event.type = MatchEventType.Goal)) {
+          return 'GL';
+        } else {
+          throw new Error('Invalid event type.');
+        }
+      };
+
+      return `${eventTypeFormatter(event)} ${eventTime}" (${playerInitials})`;
+    })
+    .join(' ');
 
   return (
     <li>{`${homeTeam} - ${awayTeam}: ${homeScore} - ${awayScore} ${scores}`}</li>

--- a/src/components/Scoreboard.test.tsx
+++ b/src/components/Scoreboard.test.tsx
@@ -8,10 +8,11 @@ const matches: Match[] = [
   {
     homeTeam: 'Team A',
     awayTeam: 'Team B',
-    homeScore: 2,
-    awayScore: 1,
+    homeScore: 0,
+    awayScore: 0,
     id: 'Team A - Team B',
     date: new Date(),
+    goals: [],
   },
   {
     homeTeam: 'Team C',
@@ -20,6 +21,7 @@ const matches: Match[] = [
     awayScore: 0,
     id: 'Team C - Team D',
     date: new Date(),
+    goals: [],
   },
 ];
 
@@ -27,8 +29,8 @@ describe('Scoreboard', () => {
   it('renders a list of scores', () => {
     render(<Scoreboard matches={matches} />);
 
-    const position1 = screen.getByText('Team A 2 - Team B 1');
-    const position2 = screen.getByText('Team C 0 - Team D 0');
+    const position1 = screen.getByText('Team A - Team B: 0 - 0');
+    const position2 = screen.getByText('Team C - Team D: 0 - 0');
 
     expect(position1.compareDocumentPosition(position2)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING

--- a/src/components/Scoreboard.test.tsx
+++ b/src/components/Scoreboard.test.tsx
@@ -12,7 +12,7 @@ const matches: Match[] = [
     awayScore: 0,
     id: 'Team A - Team B',
     date: new Date(),
-    goals: [],
+    events: [],
   },
   {
     homeTeam: 'Team C',
@@ -21,7 +21,7 @@ const matches: Match[] = [
     awayScore: 0,
     id: 'Team C - Team D',
     date: new Date(),
-    goals: [],
+    events: [],
   },
 ];
 

--- a/src/hooks/useScoreboard.test.tsx
+++ b/src/hooks/useScoreboard.test.tsx
@@ -23,6 +23,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: [],
       },
     ]);
   });
@@ -44,17 +45,22 @@ describe('useScoreboard', () => {
     let id = '';
     act(() => {
       id = result.current[1].startNewMatch('Home', 'Away');
-      result.current[1].updateScore(2, 1, id);
+      result.current[1].updateScore(0, 1, id);
     });
 
     expect(result.current[0]).toEqual([
       {
         homeTeam: 'Home',
         awayTeam: 'Away',
-        homeScore: 2,
+        homeScore: 0,
         awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: [
+          {
+            date: expect.any(Date),
+          },
+        ],
       },
     ]);
   });
@@ -87,6 +93,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: [],
       },
     ]);
   });
@@ -97,8 +104,9 @@ describe('useScoreboard', () => {
     act(() => {
       const id1 = result.current[1].startNewMatch('Home1', 'Away1');
       const id2 = result.current[1].startNewMatch('Home2', 'Away2');
-      result.current[1].updateScore(2, 0, id1);
-      result.current[1].updateScore(1, 2, id2);
+      result.current[1].updateScore(1, 0, id1);
+      result.current[1].updateScore(0, 1, id2);
+      result.current[1].updateScore(1, 1, id2);
     });
 
     expect(result.current[0]).toEqual([
@@ -106,17 +114,19 @@ describe('useScoreboard', () => {
         homeTeam: 'Home2',
         awayTeam: 'Away2',
         homeScore: 1,
-        awayScore: 2,
+        awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Home1',
         awayTeam: 'Away1',
-        homeScore: 2,
+        homeScore: 1,
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
     ]);
   });
@@ -143,6 +153,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Home1',
@@ -151,6 +162,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
     ]);
   });
@@ -171,11 +183,22 @@ describe('useScoreboard', () => {
       jest.setSystemTime(new Date(2027, 1, 1));
       const id5 = result.current[1].startNewMatch('Argentina', 'Australia');
       jest.useRealTimers();
-      result.current[1].updateScore(0, 5, id1);
-      result.current[1].updateScore(10, 2, id2);
-      result.current[1].updateScore(2, 2, id3);
-      result.current[1].updateScore(6, 6, id4);
-      result.current[1].updateScore(3, 1, id5);
+
+      const setScore = (homeScore: number, awayScore: number, id: string) => {
+        for (let i = 1; i <= homeScore; i++) {
+          result.current[1].updateScore(i, 0, id);
+        }
+
+        for (let i = 1; i <= awayScore; i++) {
+          result.current[1].updateScore(homeScore, i, id);
+        }
+      };
+
+      setScore(0, 5, id1);
+      setScore(10, 2, id2);
+      setScore(2, 2, id3);
+      setScore(6, 6, id4);
+      setScore(3, 1, id5);
     });
 
     expect(result.current[0]).toEqual([
@@ -186,6 +209,7 @@ describe('useScoreboard', () => {
         awayScore: 6,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Spain',
@@ -194,6 +218,7 @@ describe('useScoreboard', () => {
         awayScore: 2,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Mexico',
@@ -202,6 +227,7 @@ describe('useScoreboard', () => {
         awayScore: 5,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Argentina',
@@ -210,6 +236,7 @@ describe('useScoreboard', () => {
         awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
       {
         homeTeam: 'Germany',
@@ -218,6 +245,7 @@ describe('useScoreboard', () => {
         awayScore: 2,
         id: expect.any(String),
         date: expect.any(Date),
+        goals: expect.any(Array),
       },
     ]);
   });

--- a/src/hooks/useScoreboard.test.tsx
+++ b/src/hooks/useScoreboard.test.tsx
@@ -137,12 +137,10 @@ describe('useScoreboard', () => {
     act(() => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date(2023, 1, 1));
-      const id1 = result.current[1].startNewMatch('Home1', 'Away1');
+      result.current[1].startNewMatch('Home1', 'Away1');
       jest.setSystemTime(new Date(2024, 1, 1));
-      const id2 = result.current[1].startNewMatch('Home2', 'Away2');
+      result.current[1].startNewMatch('Home2', 'Away2');
       jest.useRealTimers();
-      result.current[1].updateScore(0, 0, id1);
-      result.current[1].updateScore(0, 0, id2);
     });
 
     expect(result.current[0]).toEqual([

--- a/src/hooks/useScoreboard.test.tsx
+++ b/src/hooks/useScoreboard.test.tsx
@@ -1,5 +1,11 @@
 import { renderHook, act } from '@testing-library/react';
 import { useScoreboard } from './useScoreboard';
+import { Player } from '../types/Player';
+
+const randomPlayer = (): Player => ({
+  firstName: Math.random().toString(36).substring(7),
+  lastName: Math.random().toString(36).substring(7),
+});
 
 describe('useScoreboard', () => {
   it('should start with an empty list of matches', () => {
@@ -43,9 +49,10 @@ describe('useScoreboard', () => {
     const { result } = renderHook(() => useScoreboard());
 
     let id = '';
+    const player = randomPlayer();
     act(() => {
       id = result.current[1].startNewMatch('Home', 'Away');
-      result.current[1].updateScore(0, 1, id);
+      result.current[1].updateScore(0, 1, player, id);
     });
 
     expect(result.current[0]).toEqual([
@@ -59,6 +66,7 @@ describe('useScoreboard', () => {
         goals: [
           {
             date: expect.any(Date),
+            player,
           },
         ],
       },
@@ -81,7 +89,7 @@ describe('useScoreboard', () => {
 
     act(() => {
       result.current[1].startNewMatch('Home', 'Away');
-      result.current[1].updateScore(2, 1, 'random-id');
+      result.current[1].updateScore(2, 1, randomPlayer(), 'random-id');
       result.current[1].finishMatch('random-id');
     });
 
@@ -104,9 +112,9 @@ describe('useScoreboard', () => {
     act(() => {
       const id1 = result.current[1].startNewMatch('Home1', 'Away1');
       const id2 = result.current[1].startNewMatch('Home2', 'Away2');
-      result.current[1].updateScore(1, 0, id1);
-      result.current[1].updateScore(0, 1, id2);
-      result.current[1].updateScore(1, 1, id2);
+      result.current[1].updateScore(1, 0, randomPlayer(), id1);
+      result.current[1].updateScore(0, 1, randomPlayer(), id2);
+      result.current[1].updateScore(1, 1, randomPlayer(), id2);
     });
 
     expect(result.current[0]).toEqual([
@@ -184,11 +192,11 @@ describe('useScoreboard', () => {
 
       const setScore = (homeScore: number, awayScore: number, id: string) => {
         for (let i = 1; i <= homeScore; i++) {
-          result.current[1].updateScore(i, 0, id);
+          result.current[1].updateScore(i, 0, randomPlayer(), id);
         }
 
         for (let i = 1; i <= awayScore; i++) {
-          result.current[1].updateScore(homeScore, i, id);
+          result.current[1].updateScore(homeScore, i, randomPlayer(), id);
         }
       };
 

--- a/src/hooks/useScoreboard.test.tsx
+++ b/src/hooks/useScoreboard.test.tsx
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
 import { useScoreboard } from './useScoreboard';
 import { Player } from '../types/Player';
+import { MatchEventType } from '../types/MatchEventType';
+import { CardType } from '../types/CardType';
 
 const randomPlayer = (): Player => ({
   firstName: Math.random().toString(36).substring(7),
@@ -29,7 +31,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: [],
+        events: [],
       },
     ]);
   });
@@ -63,10 +65,77 @@ describe('useScoreboard', () => {
         awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: [
+        events: [
           {
+            type: MatchEventType.Goal,
             date: expect.any(Date),
             player,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should be able to add cards to a match', () => {
+    const { result } = renderHook(() => useScoreboard());
+
+    let id = '';
+    const player = randomPlayer();
+    act(() => {
+      id = result.current[1].startNewMatch('Home', 'Away');
+      result.current[1].addCard(CardType.Yellow, player, id);
+    });
+
+    expect(result.current[0]).toEqual([
+      {
+        homeTeam: 'Home',
+        awayTeam: 'Away',
+        homeScore: 0,
+        awayScore: 0,
+        id: expect.any(String),
+        date: expect.any(Date),
+        events: [
+          {
+            type: MatchEventType.Card,
+            date: expect.any(Date),
+            player,
+            cardType: CardType.Yellow,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should be able to add mix of goals and cards to a match', () => {
+    const { result } = renderHook(() => useScoreboard());
+
+    let id = '';
+    const player = randomPlayer();
+    act(() => {
+      id = result.current[1].startNewMatch('Home', 'Away');
+      result.current[1].updateScore(0, 1, player, id);
+      result.current[1].addCard(CardType.Yellow, player, id);
+    });
+
+    expect(result.current[0]).toEqual([
+      {
+        homeTeam: 'Home',
+        awayTeam: 'Away',
+        homeScore: 0,
+        awayScore: 1,
+        id: expect.any(String),
+        date: expect.any(Date),
+        events: [
+          {
+            type: MatchEventType.Goal,
+            date: expect.any(Date),
+            player,
+          },
+          {
+            type: MatchEventType.Card,
+            date: expect.any(Date),
+            player,
+            cardType: CardType.Yellow,
           },
         ],
       },
@@ -101,7 +170,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: [],
+        events: [],
       },
     ]);
   });
@@ -125,7 +194,7 @@ describe('useScoreboard', () => {
         awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Home1',
@@ -134,7 +203,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
     ]);
   });
@@ -159,7 +228,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Home1',
@@ -168,7 +237,7 @@ describe('useScoreboard', () => {
         awayScore: 0,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
     ]);
   });
@@ -215,7 +284,7 @@ describe('useScoreboard', () => {
         awayScore: 6,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Spain',
@@ -224,7 +293,7 @@ describe('useScoreboard', () => {
         awayScore: 2,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Mexico',
@@ -233,7 +302,7 @@ describe('useScoreboard', () => {
         awayScore: 5,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Argentina',
@@ -242,7 +311,7 @@ describe('useScoreboard', () => {
         awayScore: 1,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
       {
         homeTeam: 'Germany',
@@ -251,7 +320,7 @@ describe('useScoreboard', () => {
         awayScore: 2,
         id: expect.any(String),
         date: expect.any(Date),
-        goals: expect.any(Array),
+        events: expect.any(Array),
       },
     ]);
   });

--- a/src/hooks/useScoreboard.tsx
+++ b/src/hooks/useScoreboard.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Match } from '../types/Match';
 import { Player } from '../types/Player';
+import { MatchEventType } from '../types/MatchEventType';
+import { CardType } from '../types/CardType';
 
 /**
  * Interface for scoreboard functions.
@@ -27,6 +29,12 @@ export interface ScoreboardFunctions {
     id: string
   ) => void;
   /**
+   * Updates the score of a match. Accepts only incremental score changes.
+   * @param card - Card containing player and yellow/red information.
+   * @param id - The ID of the match to update.
+   */
+  addCard: (type: CardType, player: Player, id: string) => void;
+  /**
    * Finishes a match.
    * @param id - The ID of the match to finish.
    */
@@ -48,7 +56,7 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
       awayScore: 0,
       id: `${homeTeam} - ${awayTeam}`,
       date: new Date(),
-      goals: [],
+      events: [],
     };
 
     setMatches((prevState) => {
@@ -79,7 +87,8 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
         return prevState;
       }
 
-      updatedMatches[index].goals.push({
+      updatedMatches[index].events.push({
+        type: MatchEventType.Goal,
         date: new Date(),
         player,
       });
@@ -106,6 +115,22 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
     });
   };
 
+  const addCard = (type: CardType, player: Player, id: string) => {
+    setMatches((prevState) => {
+      const updatedMatches = [...prevState];
+      const index = updatedMatches.findIndex((match) => match.id === id);
+      if (index === -1) return prevState;
+
+      updatedMatches[index].events.push({
+        type: MatchEventType.Card,
+        player,
+        cardType: type,
+        date: new Date(),
+      });
+      return updatedMatches;
+    });
+  };
+
   const finishMatch = (id: string) => {
     setMatches((prevState) => {
       const updatedMatches = [...prevState];
@@ -116,5 +141,5 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
     });
   };
 
-  return [matches, { startNewMatch, updateScore, finishMatch }];
+  return [matches, { startNewMatch, updateScore, addCard, finishMatch }];
 }

--- a/src/hooks/useScoreboard.tsx
+++ b/src/hooks/useScoreboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Match } from '../types/Match';
+import { Player } from '../types/Player';
 
 /**
  * Interface for scoreboard functions.
@@ -13,12 +14,18 @@ export interface ScoreboardFunctions {
    */
   startNewMatch: (homeTeam: string, awayTeam: string) => string;
   /**
-   * Updates the score of a match.
+   * Updates the score of a match. Accepts only incremental score changes.
    * @param homeScore - The new score of the home team.
    * @param awayScore - The new score of the away team.
+   * @param player - Player who scored the goal.
    * @param id - The ID of the match to update.
    */
-  updateScore: (homeScore: number, awayScore: number, id: string) => void;
+  updateScore: (
+    homeScore: number,
+    awayScore: number,
+    player: Player,
+    id: string
+  ) => void;
   /**
    * Finishes a match.
    * @param id - The ID of the match to finish.
@@ -54,7 +61,12 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
     return newMatch.id;
   };
 
-  const updateScore = (homeScore: number, awayScore: number, id: string) => {
+  const updateScore = (
+    homeScore: number,
+    awayScore: number,
+    player: Player,
+    id: string
+  ) => {
     setMatches((prevState) => {
       const updatedMatches = [...prevState];
       const index = updatedMatches.findIndex((match) => match.id === id);
@@ -69,6 +81,7 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
 
       updatedMatches[index].goals.push({
         date: new Date(),
+        player,
       });
 
       updatedMatches[index].homeScore = homeScore;

--- a/src/hooks/useScoreboard.tsx
+++ b/src/hooks/useScoreboard.tsx
@@ -41,6 +41,7 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
       awayScore: 0,
       id: `${homeTeam} - ${awayTeam}`,
       date: new Date(),
+      goals: [],
     };
 
     setMatches((prevState) => {
@@ -58,6 +59,18 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
       const updatedMatches = [...prevState];
       const index = updatedMatches.findIndex((match) => match.id === id);
       if (index === -1) return prevState;
+
+      const prevHomeScore = updatedMatches[index].homeScore;
+      const prevAwayScore = updatedMatches[index].awayScore;
+
+      if (homeScore - prevHomeScore + awayScore - prevAwayScore !== 1) {
+        return prevState;
+      }
+
+      updatedMatches[index].goals.push({
+        date: new Date(),
+      });
+
       updatedMatches[index].homeScore = homeScore;
       updatedMatches[index].awayScore = awayScore;
 

--- a/src/hooks/useScoreboard.tsx
+++ b/src/hooks/useScoreboard.tsx
@@ -48,7 +48,7 @@ export function useScoreboard(): [Match[], ScoreboardFunctions] {
       const index = prevState.findIndex((match) => match.id === newMatch.id);
       if (index !== -1) return prevState;
 
-      return [...prevState, newMatch];
+      return [newMatch, ...prevState];
     });
 
     return newMatch.id;

--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -1,0 +1,9 @@
+import { CardType } from './CardType';
+import { MatchEventBase } from './MatchEventBase';
+import { MatchEventType } from './MatchEventType';
+
+export interface Card extends MatchEventBase {
+  type: MatchEventType.Card;
+  cardType: CardType;
+  date: Date;
+}

--- a/src/types/CardType.ts
+++ b/src/types/CardType.ts
@@ -1,0 +1,4 @@
+export enum CardType {
+  Red = 'RED',
+  Yellow = 'YELLOW',
+}

--- a/src/types/Goal.ts
+++ b/src/types/Goal.ts
@@ -1,3 +1,6 @@
+import { Player } from './Player';
+
 export interface Goal {
   date: Date;
+  player: Player;
 }

--- a/src/types/Goal.ts
+++ b/src/types/Goal.ts
@@ -1,6 +1,6 @@
-import { Player } from './Player';
+import { MatchEventBase } from './MatchEventBase';
+import { MatchEventType } from './MatchEventType';
 
-export interface Goal {
-  date: Date;
-  player: Player;
+export interface Goal extends MatchEventBase {
+  type: MatchEventType.Goal;
 }

--- a/src/types/Goal.ts
+++ b/src/types/Goal.ts
@@ -1,0 +1,3 @@
+export interface Goal {
+  date: Date;
+}

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,3 +1,5 @@
+import { Goal } from './Goal';
+
 export interface Match {
   id: string;
   homeTeam: string;
@@ -5,4 +7,5 @@ export interface Match {
   homeScore: number;
   awayScore: number;
   date: Date;
+  goals: Goal[];
 }

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,4 +1,4 @@
-import { Goal } from './Goal';
+import { MatchEvent } from './MatchEvent';
 
 export interface Match {
   id: string;
@@ -7,5 +7,5 @@ export interface Match {
   homeScore: number;
   awayScore: number;
   date: Date;
-  goals: Goal[];
+  events: MatchEvent[];
 }

--- a/src/types/MatchEvent.ts
+++ b/src/types/MatchEvent.ts
@@ -1,0 +1,4 @@
+import { Goal } from './Goal';
+import { Card } from './Card';
+
+export type MatchEvent = Goal | Card;

--- a/src/types/MatchEventBase.ts
+++ b/src/types/MatchEventBase.ts
@@ -1,0 +1,8 @@
+import { MatchEventType } from './MatchEventType';
+import { Player } from './Player';
+
+export interface MatchEventBase {
+  type: MatchEventType;
+  date: Date;
+  player: Player;
+}

--- a/src/types/MatchEventType.ts
+++ b/src/types/MatchEventType.ts
@@ -1,0 +1,4 @@
+export enum MatchEventType {
+  Goal = 'GOAL',
+  Card = 'CARD',
+}

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -1,0 +1,4 @@
+export interface Player {
+  firstName: string;
+  lastName: string;
+}


### PR DESCRIPTION
- only incremental score changes are now allowed
- player name needs to be provided when updating score
- add red/yellow cards via `addCard` method returned by `useScoreboard` hook
- `Score` component now displays goals and cards along with times and player initials:
```
Real Madrid - Barcelona: 1 - 0 GL 5" (R.L) YL 20" (L.M)
```